### PR TITLE
ci: add Dependabot for GitHub Actions version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    cooldown:
+      default-days: 7
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      minor-and-patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
Adds a `.github/dependabot.yml` configuration with a `github-actions` ecosystem entry.

Dependabot will automatically open PRs to keep pinned SHA digests up-to-date as new versions of Actions are released, closing the loop opened by #17.

---
_Generated by [ds-security-scanning](https://github.com/developmentseed/ds-security-scanning) zizmor-cli-unpinned-uses_